### PR TITLE
Updates in P-Masstree

### DIFF
--- a/P-ART/N.cpp
+++ b/P-ART/N.cpp
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <algorithm>
+#include <emmintrin.h>
 
 #include "N.h"
 #include "N4.cpp"
@@ -53,6 +54,13 @@ namespace ART_ROWEX {
         if (back)
             mfence();
     }
+
+    inline void N::movnt64(uint64_t *dest, uint64_t const &src) {
+        mfence();
+        _mm_stream_si64((long long int *)dest, *(long long int *)&src);
+        mfence();
+    }
+
 #ifdef LOCK_INIT
     void lock_initialization () {
         printf("lock table size = %lu\n", lock_initializer.size());

--- a/P-ART/N.h
+++ b/P-ART/N.h
@@ -158,6 +158,8 @@ namespace ART_ROWEX {
         static inline void mfence() __attribute__((always_inline));
 
         static inline void clflush(char *data, int len, bool front, bool back) __attribute__((always_inline));
+
+        static inline void movnt64(uint64_t *dest, uint64_t const &src) __attribute__((always_inline));
     };
 
     class N4 : public N {


### PR DESCRIPTION
The implementation of P-Masstree is updated to use optimistic locks for reading paths (get, scan, and tree traversals) instead of atomic snapshot techniques employed in the prior version. The original Masstree also employs optimistic locks, so these updates just result in making P-Masstree more faithfully follow the original way of implementation. Another benefit from this update is P-Masstree can provide read-committed without employing non-temporal stores since readers in P-Masstree never return data before in-progress writes to the same object are finished.