### PR TITLE
Persistency Race Bug Fix

### DIFF
--- a/P-ART/N.cpp
+++ b/P-ART/N.cpp
@@ -223,7 +223,7 @@ namespace ART_ROWEX {
         switch (node->getType()) {
             case NTypes::N4: {
                 auto n = static_cast<N4 *>(node);
-                if (n->compactCount.load(std::memory_order_acquire) == 4 && n->count <= 3) {
+                if (n->compactCount.load(std::memory_order_acquire) == 4 && n->count.load(std::memory_order_acquire) <= 3) {
                     if (!insertCompact<N4>(n, parentNode, keyParent, key, val, threadInfo, needRestart))
                         insertGrow<N4, N16>(n, parentNode, keyParent, key, val, threadInfo, needRestart);
                     break;
@@ -233,7 +233,7 @@ namespace ART_ROWEX {
             }
             case NTypes::N16: {
                 auto n = static_cast<N16 *>(node);
-                if (n->compactCount.load(std::memory_order_acquire) == 16 && n->count <= 14) {
+                if (n->compactCount.load(std::memory_order_acquire) == 16 && n->count.load(std::memory_order_acquire) <= 14) {
                     if (!insertCompact<N16>(n, parentNode, keyParent, key, val, threadInfo, needRestart))
                         insertGrow<N16, N48>(n, parentNode, keyParent, key, val, threadInfo, needRestart);
                     break;
@@ -243,7 +243,7 @@ namespace ART_ROWEX {
             }
             case NTypes::N48: {
                 auto n = static_cast<N48 *>(node);
-                if (n->compactCount.load(std::memory_order_acquire) == 48 && n->count != 48) {
+                if (n->compactCount.load(std::memory_order_acquire) == 48 && n->count.load(std::memory_order_acquire) != 48) {
                     if (!insertCompact<N48>(n, parentNode, keyParent, key, val, threadInfo, needRestart))
                         insertGrow<N48, N256>(n, parentNode, keyParent, key, val, threadInfo, needRestart);
                     break;

--- a/P-ART/N.cpp
+++ b/P-ART/N.cpp
@@ -223,7 +223,7 @@ namespace ART_ROWEX {
         switch (node->getType()) {
             case NTypes::N4: {
                 auto n = static_cast<N4 *>(node);
-                if (n->compactCount == 4 && n->count <= 3) {
+                if (n->compactCount.load(std::memory_order_acquire) == 4 && n->count <= 3) {
                     if (!insertCompact<N4>(n, parentNode, keyParent, key, val, threadInfo, needRestart))
                         insertGrow<N4, N16>(n, parentNode, keyParent, key, val, threadInfo, needRestart);
                     break;
@@ -233,7 +233,7 @@ namespace ART_ROWEX {
             }
             case NTypes::N16: {
                 auto n = static_cast<N16 *>(node);
-                if (n->compactCount == 16 && n->count <= 14) {
+                if (n->compactCount.load(std::memory_order_acquire) == 16 && n->count <= 14) {
                     if (!insertCompact<N16>(n, parentNode, keyParent, key, val, threadInfo, needRestart))
                         insertGrow<N16, N48>(n, parentNode, keyParent, key, val, threadInfo, needRestart);
                     break;
@@ -243,7 +243,7 @@ namespace ART_ROWEX {
             }
             case NTypes::N48: {
                 auto n = static_cast<N48 *>(node);
-                if (n->compactCount == 48 && n->count != 48) {
+                if (n->compactCount.load(std::memory_order_acquire) == 48 && n->count != 48) {
                     if (!insertCompact<N48>(n, parentNode, keyParent, key, val, threadInfo, needRestart))
                         insertGrow<N48, N256>(n, parentNode, keyParent, key, val, threadInfo, needRestart);
                     break;

--- a/P-ART/N.h
+++ b/P-ART/N.h
@@ -70,7 +70,7 @@ namespace ART_ROWEX {
         // version 1, unlocked, not obsolete
         std::atomic<Prefix> prefix;
         const uint32_t level;
-        uint16_t count = 0;
+        std::atomic<uint16_t> count {0};
         std::atomic<uint16_t> compactCount{0};
 
 

--- a/P-ART/N.h
+++ b/P-ART/N.h
@@ -71,7 +71,7 @@ namespace ART_ROWEX {
         std::atomic<Prefix> prefix;
         const uint32_t level;
         uint16_t count = 0;
-        uint16_t compactCount = 0;
+        std::atomic<uint16_t> compactCount{0};
 
 
 

--- a/P-ART/N16.cpp
+++ b/P-ART/N16.cpp
@@ -11,7 +11,7 @@ namespace ART_ROWEX {
         }
 
         uint16_t nextIndex = compactCount.fetch_add(1, std::memory_order_acq_rel);
-        count++;
+        count.fetch_add(1, std::memory_order_acq_rel);
 
         if (flush) {
             keys[nextIndex].store(flipSign(key), std::memory_order_release);
@@ -74,7 +74,7 @@ namespace ART_ROWEX {
     }
 
     bool N16::remove(uint8_t k, bool force, bool flush) {
-        if (count <= 3 && !force) {
+        if (count.load(std::memory_order_acquire) <= 3 && !force) {
             return false;
         }
         auto leafPlace = getChildPos(k);
@@ -85,7 +85,7 @@ namespace ART_ROWEX {
         else
             leafPlace->store(nullptr, std::memory_order_relaxed);
 
-        count--;
+        count.fetch_sub(1, std::memory_order_acq_rel);
         assert(getChild(k) == nullptr);
         return true;
     }

--- a/P-ART/N16.cpp
+++ b/P-ART/N16.cpp
@@ -6,11 +6,11 @@
 namespace ART_ROWEX {
 
     inline bool N16::insert(uint8_t key, N *n, bool flush) {
-        if (compactCount == 16) {
+        if (compactCount.load(std::memory_order_acquire) == 16) {
             return false;
         }
 
-        uint16_t nextIndex = compactCount++;
+        uint16_t nextIndex = compactCount.fetch_add(1, std::memory_order_acq_rel);
         count++;
 
         if (flush) {
@@ -28,7 +28,7 @@ namespace ART_ROWEX {
 
     template<class NODE>
     void N16::copyTo(NODE *n) const {
-        for (unsigned i = 0; i < compactCount; i++) {
+        for (unsigned i = 0; i < compactCount.load(std::memory_order_acquire); i++) {
             N *child = children[i].load();
             if (child != nullptr) {
                 n->insert(flipSign(keys[i]), child, false);
@@ -45,7 +45,7 @@ namespace ART_ROWEX {
     std::atomic<N *> *N16::getChildPos(const uint8_t k) {
         __m128i cmp = _mm_cmpeq_epi8(_mm_set1_epi8(flipSign(k)),
                                      _mm_loadu_si128(reinterpret_cast<const __m128i *>(keys)));
-        unsigned bitfield = _mm_movemask_epi8(cmp) & ((1 << compactCount) - 1);
+        unsigned bitfield = _mm_movemask_epi8(cmp) & ((1 << compactCount.load(std::memory_order_acquire)) - 1);
         while (bitfield) {
             uint8_t pos = ctz(bitfield);
 
@@ -105,7 +105,7 @@ namespace ART_ROWEX {
     }
 
     void N16::deleteChildren() {
-        for (std::size_t i = 0; i < compactCount; ++i) {
+        for (std::size_t i = 0; i < compactCount.load(std::memory_order_acquire); ++i) {
             if (children[i].load() != nullptr) {
                 N::deleteChildren(children[i]);
                 N::deleteNode(children[i]);
@@ -116,7 +116,7 @@ namespace ART_ROWEX {
     void N16::getChildren(uint8_t start, uint8_t end, std::tuple<uint8_t, N *> *&children,
                           uint32_t &childrenCount) const {
         childrenCount = 0;
-        for (int i = 0; i < compactCount; ++i) {
+        for (int i = 0; i < compactCount.load(std::memory_order_acquire); ++i) {
             uint8_t key = flipSign(this->keys[i]);
             if (key >= start && key <= end) {
                 N *child = this->children[i].load();
@@ -133,7 +133,7 @@ namespace ART_ROWEX {
 
     uint32_t N16::getCount() const {
         uint32_t cnt = 0;
-        for (uint32_t i = 0; i < compactCount && cnt < 3; i++) {
+        for (uint32_t i = 0; i < compactCount.load(std::memory_order_acquire) && cnt < 3; i++) {
             N *child = children[i].load();
             if (child != nullptr)
                 ++cnt;

--- a/P-ART/N4.cpp
+++ b/P-ART/N4.cpp
@@ -20,7 +20,7 @@ namespace ART_ROWEX {
         }
 
         uint16_t nextIndex = compactCount.fetch_add(1, std::memory_order_acq_rel);
-        count++;
+        count.fetch_add(1, std::memory_order_acq_rel);
 
         if (flush) {
             keys[nextIndex].store(key, std::memory_order_release);
@@ -71,7 +71,7 @@ namespace ART_ROWEX {
             if (children[i] != nullptr && keys[i].load() == k) {
                 if (flush) movnt64((uint64_t *)&children[i], (uint64_t)nullptr, false, true);
                 else children[i].store(nullptr, std::memory_order_relaxed);
-                count--;
+                count.fetch_sub(1, std::memory_order_acq_rel);
                 return true;
             }
         }

--- a/P-ART/N4.cpp
+++ b/P-ART/N4.cpp
@@ -6,7 +6,7 @@ namespace ART_ROWEX {
 
 
     void N4::deleteChildren() {
-        for (uint32_t i = 0; i < compactCount; ++i) {
+        for (uint32_t i = 0; i < compactCount.load(std::memory_order_acquire); ++i) {
             if (children[i].load() != nullptr) {
                 N::deleteChildren(children[i]);
                 N::deleteNode(children[i]);
@@ -15,11 +15,11 @@ namespace ART_ROWEX {
     }
 
     inline bool N4::insert(uint8_t key, N *n, bool flush) {
-        if (compactCount == 4) {
+        if (compactCount.load(std::memory_order_acquire) == 4) {
             return false;
         }
 
-        uint16_t nextIndex = compactCount++;
+        uint16_t nextIndex = compactCount.fetch_add(1, std::memory_order_acq_rel);
         count++;
 
         if (flush) {
@@ -36,7 +36,7 @@ namespace ART_ROWEX {
 
     template<class NODE>
     void N4::copyTo(NODE *n) const {
-        for (uint32_t i = 0; i < compactCount; ++i) {
+        for (uint32_t i = 0; i < compactCount.load(std::memory_order_acquire); ++i) {
             N *child = children[i].load();
             if (child != nullptr) {
                 n->insert(keys[i].load(), child, false);
@@ -45,7 +45,7 @@ namespace ART_ROWEX {
     }
 
     void N4::change(uint8_t key, N *val) {
-        for (uint32_t i = 0; i < compactCount; ++i) {
+        for (uint32_t i = 0; i < compactCount.load(std::memory_order_acquire); ++i) {
             N *child = children[i].load();
             if (child != nullptr && keys[i].load() == key) {
                 movnt64((uint64_t *)&children[i], (uint64_t) val, false, true);
@@ -67,7 +67,7 @@ namespace ART_ROWEX {
     }
 
     bool N4::remove(uint8_t k, bool force, bool flush) {
-        for (uint32_t i = 0; i < compactCount; ++i) {
+        for (uint32_t i = 0; i < compactCount.load(std::memory_order_acquire); ++i) {
             if (children[i] != nullptr && keys[i].load() == k) {
                 if (flush) movnt64((uint64_t *)&children[i], (uint64_t)nullptr, false, true);
                 else children[i].store(nullptr, std::memory_order_relaxed);
@@ -94,7 +94,7 @@ namespace ART_ROWEX {
     }
 
     std::tuple<N *, uint8_t> N4::getSecondChild(const uint8_t key) const {
-        for (uint32_t i = 0; i < compactCount; ++i) {
+        for (uint32_t i = 0; i < compactCount.load(std::memory_order_acquire); ++i) {
             N *child = children[i].load();
             if (child != nullptr) {
                 uint8_t k = keys[i].load();
@@ -126,7 +126,7 @@ namespace ART_ROWEX {
 
     uint32_t N4::getCount() const {
         uint32_t cnt = 0;
-        for (uint32_t i = 0; i < compactCount && cnt < 3; i++) {
+        for (uint32_t i = 0; i < compactCount.load(std::memory_order_acquire) && cnt < 3; i++) {
             N *child = children[i].load();
             if (child != nullptr)
                 cnt++;

--- a/P-ART/N48.cpp
+++ b/P-ART/N48.cpp
@@ -33,7 +33,7 @@ namespace ART_ROWEX {
         }
 
         compactCount.fetch_add(1, std::memory_order_acq_rel);
-        count++;
+        count.fetch_add(1, std::memory_order_acq_rel);
         return true;
     }
 
@@ -63,7 +63,7 @@ namespace ART_ROWEX {
     }
 
     bool N48::remove(uint8_t k, bool force, bool flush) {
-        if (count <= 12 && !force) {
+        if (count.load(std::memory_order_acquire) <= 12 && !force) {
             return false;
         }
         assert(childIndex[k] != emptyMarker);
@@ -81,7 +81,7 @@ namespace ART_ROWEX {
             childIndex[k].store(emptyMarker, std::memory_order_relaxed);
         }
 
-        count--;
+        count.fetch_sub(1, std::memory_order_acq_rel);
         assert(getChild(k) == nullptr);
         return true;
     }

--- a/P-ART/N48.cpp
+++ b/P-ART/N48.cpp
@@ -5,34 +5,34 @@
 namespace ART_ROWEX {
 
     inline bool N48::insert(uint8_t key, N *n, bool flush) {
-        if (compactCount == 48) {
+        if (compactCount.load(std::memory_order_acquire) == 48) {
             return false;
         }
 
         while (true) {
-            if (children[compactCount].load() == nullptr)
+            if (children[compactCount.load(std::memory_order_acquire)].load() == nullptr)
                 break;
             else {
-                compactCount++;
-                if (compactCount == 48)
+                compactCount.fetch_add(1, std::memory_order_acq_rel);
+                if (compactCount.load(std::memory_order_acquire) == 48)
                     return false;
             }
         }
 
         if (flush) {
-            children[compactCount].store(n, std::memory_order_release);
-            clflush((char *)&children[compactCount], sizeof(N *), false, true);
+            children[compactCount.load(std::memory_order_acquire)].store(n, std::memory_order_release);
+            clflush((char *)&children[compactCount.load(std::memory_order_acquire)], sizeof(N *), false, true);
             uint64_t *childIndex64 = (uint64_t *)childIndex;
             uint64_t index64 = childIndex64[key/8];
             uint8_t *index8 = (uint8_t *)&index64;
-            index8[key%8] = compactCount;
+            index8[key%8] = compactCount.load(std::memory_order_acquire);
             movnt64((uint64_t *)&childIndex64[key/8], index64, false, true);
         } else {
-            children[compactCount].store(n, std::memory_order_relaxed);
-            childIndex[key].store(compactCount, std::memory_order_relaxed);
+            children[compactCount.load(std::memory_order_acquire)].store(n, std::memory_order_relaxed);
+            childIndex[key].store(compactCount.load(std::memory_order_acquire), std::memory_order_relaxed);
         }
 
-        compactCount++;
+        compactCount.fetch_add(1, std::memory_order_acq_rel);
         count++;
         return true;
     }

--- a/P-Masstree/masstree.h
+++ b/P-Masstree/masstree.h
@@ -329,7 +329,7 @@ class permuter {
 class leafnode {
     private:
         permuter permutation;                                   // 8bytes
-        leafnode *next;                                         // 8bytes
+        std::atomic<leafnode *> next;                           // 8bytes
         std::atomic<uint64_t> typeVersionLockObsolete{0b100};   // 8bytes
         leafnode *leftmost_ptr;                                 // 8bytes
         uint64_t highest;                                       // 8bytes
@@ -414,7 +414,7 @@ class leafnode {
 
         leafnode *leftmost() {return leftmost_ptr;}
 
-        leafnode *next_() {return next;}
+        leafnode *next_() {return next.load(std::memory_order_acquire);}
 
         uint64_t highest_() {return highest;}
 
@@ -430,7 +430,7 @@ class leafnode {
 
         leafvalue *smallest_leaf(size_t key_len, uint64_t value);
 
-        leafnode *search_for_leftsibling(std::atomic<void *>*root, uint64_t key, uint32_t level, leafnode *right);
+        leafnode *search_for_leftsibling(std::atomic<void*> *root1, void **root, uint64_t key, uint32_t level, leafnode *right);
 };
 
 }

--- a/P-Masstree/masstree.h
+++ b/P-Masstree/masstree.h
@@ -106,8 +106,7 @@ class masstree {
 
 class permuter {
     public:
-        permuter() {
-            x_ = 0ULL;
+        permuter(): x_(0ULL) {
         }
 
         permuter(uint64_t x) : x_(x) {
@@ -134,13 +133,13 @@ class permuter {
 
         /** @brief Return the permuter's size. */
         int size() const {
-            return x_ & LEAF_WIDTH;
+            return x_.load(std::memory_order_acquire) & LEAF_WIDTH;
         }
 
         /** @brief Return the permuter's element @a i.
           @pre 0 <= i < width */
         int operator[](int i) const {
-            return (x_ >> ((i << 2) + 4)) & LEAF_WIDTH;
+            return (x_.load(std::memory_order_acquire) >> ((i << 2) + 4)) & LEAF_WIDTH;
         }
 
         int back() const {
@@ -148,15 +147,15 @@ class permuter {
         }
 
         uint64_t value() const {
-            return x_;
+            return x_.load(std::memory_order_acquire);
         }
 
         uint64_t value_from(int i) const {
-            return x_ >> ((i + 1) << 2);
+            return x_.load(std::memory_order_acquire) >> ((i + 1) << 2);
         }
 
         void set_size(int n) {
-            x_ = (x_ & ~(uint64_t)LEAF_WIDTH) | n;
+            x_.store( (x_.load(std::memory_order_acquire) & ~(uint64_t)LEAF_WIDTH) | n, std::memory_order_release);
         }
 
         /** @brief Allocate a new element and insert it at position @a i.
@@ -180,11 +179,12 @@ class permuter {
         int insert_from_back(int i) {
             int value = back();
             // increment size, leave lower slots unchanged
-            x_ = ((x_ + 1) & (((uint64_t) 16 << (i << 2)) - 1))
+            x_.store( ((x_.load(std::memory_order_acquire) + 1) & (((uint64_t) 16 << (i << 2)) - 1))
                 // insert slot
                 | ((uint64_t) value << ((i << 2) + 4))
                 // shift up unchanged higher entries & empty slots
-                | ((x_ << 4) & ~(((uint64_t) 256 << (i << 2)) - 1));
+                | ((x_.load(std::memory_order_acquire) << 4) & ~(((uint64_t) 256 << (i << 2)) - 1)),
+                std::memory_order_release);
             return value;
         }
 
@@ -197,13 +197,14 @@ class permuter {
             int value = (*this)[si];
             uint64_t mask = ((uint64_t) 256 << (si << 2)) - 1;
             // increment size, leave lower slots unchanged
-            x_ = ((x_ + 1) & (((uint64_t) 16 << (di << 2)) - 1))
+            x_.store( ((x_.load(std::memory_order_acquire) + 1) & (((uint64_t) 16 << (di << 2)) - 1))
                 // insert slot
                 | ((uint64_t) value << ((di << 2) + 4))
                 // shift up unchanged higher entries & empty slots
-                | ((x_ << 4) & mask & ~(((uint64_t) 256 << (di << 2)) - 1))
+                | ((x_.load(std::memory_order_acquire) << 4) & mask & ~(((uint64_t) 256 << (di << 2)) - 1))
                 // leave uppermost slots alone
-                | (x_ & ~mask);
+                | (x_.load(std::memory_order_acquire) & ~mask),
+                std::memory_order_release);
         }
         /** @brief Remove the element at position @a i.
           @pre 0 <= @a i < @a size()
@@ -223,18 +224,19 @@ class permuter {
           <li>q[q.size()] == p[i]</li>
           </ul> */
         void remove(int i) {
-            if (int(x_ & 15) == i + 1)
-                --x_;
+            if (int(x_.load(std::memory_order_acquire) & 15) == i + 1)
+                x_.fetch_sub(1, std::memory_order_acq_rel);
             else {
-                int rot_amount = ((x_ & 15) - i - 1) << 2;
+                int rot_amount = ((x_.load(std::memory_order_acquire) & 15) - i - 1) << 2;
                 uint64_t rot_mask =
                     (((uint64_t) 16 << rot_amount) - 1) << ((i + 1) << 2);
                 // decrement size, leave lower slots unchanged
-                x_ = ((x_ - 1) & ~rot_mask)
+                x_.store( ((x_.load(std::memory_order_acquire) - 1) & ~rot_mask)
                     // shift higher entries down
-                    | (((x_ & rot_mask) >> 4) & rot_mask)
+                    | (((x_.load(std::memory_order_acquire) & rot_mask) >> 4) & rot_mask)
                     // shift value up
-                    | (((x_ & rot_mask) << rot_amount) & rot_mask);
+                    | (((x_.load(std::memory_order_acquire) & rot_mask) << rot_amount) & rot_mask),
+                    std::memory_order_release);
             }
         }
         /** @brief Remove the element at position @a i to the back.
@@ -257,13 +259,14 @@ class permuter {
         void remove_to_back(int i) {
             uint64_t mask = ~(((uint64_t) 16 << (i << 2)) - 1);
             // clear unused slots
-            uint64_t x = x_ & (((uint64_t) 16 << (LEAF_WIDTH << 2)) - 1);
+            uint64_t x = x_.load(std::memory_order_acquire) & (((uint64_t) 16 << (LEAF_WIDTH << 2)) - 1);
             // decrement size, leave lower slots unchanged
-            x_ = ((x - 1) & ~mask)
+            x_.store( ((x - 1) & ~mask)
                 // shift higher entries down
                 | ((x >> 4) & mask)
                 // shift removed element up
-                | ((x & mask) << ((LEAF_WIDTH - i - 1) << 2));
+                | ((x & mask) << ((LEAF_WIDTH - i - 1) << 2)),
+                std::memory_order_release);
         }
         /** @brief Rotate the permuter's elements between @a i and size().
           @pre 0 <= @a i <= @a j <= size()
@@ -283,39 +286,40 @@ class permuter {
         void rotate(int i, int j) {
             uint64_t mask = (i == LEAF_WIDTH ? (uint64_t) 0 : (uint64_t) 16 << (i << 2)) - 1;
             // clear unused slots
-            uint64_t x = x_ & (((uint64_t) 16 << (LEAF_WIDTH << 2)) - 1);
-            x_ = (x & mask)
+            uint64_t x = x_.load(std::memory_order_acquire) & (((uint64_t) 16 << (LEAF_WIDTH << 2)) - 1);
+            x_.store( (x & mask)
                 | ((x >> ((j - i) << 2)) & ~mask)
-                | ((x & ~mask) << ((LEAF_WIDTH - j) << 2));
+                | ((x & ~mask) << ((LEAF_WIDTH - j) << 2)),
+                std::memory_order_release);
         }
         /** @brief Exchange the elements at positions @a i and @a j. */
         void exchange(int i, int j) {
-            uint64_t diff = ((x_ >> (i << 2)) ^ (x_ >> (j << 2))) & 240;
-            x_ ^= (diff << (i << 2)) | (diff << (j << 2));
+            uint64_t diff = ((x_.load(std::memory_order_acquire) >> (i << 2)) ^ (x_.load(std::memory_order_acquire) >> (j << 2))) & 240;
+            x_.fetch_xor( (diff << (i << 2)) | (diff << (j << 2)), std::memory_order_acq_rel);
         }
         /** @brief Exchange positions of values @a x and @a y. */
         void exchange_values(int x, int y) {
-            uint64_t diff = 0, p = x_;
+            uint64_t diff = 0, p = x_.load(std::memory_order_acquire);
             for (int i = 0; i < LEAF_WIDTH; ++i, diff <<= 4, p <<= 4) {
                 int v = (p >> (LEAF_WIDTH << 2)) & 15;
                 diff ^= -((v == x) | (v == y)) & (x ^ y);
             }
-            x_ ^= diff;
+            x_.fetch_xor( diff, std::memory_order_acq_rel);
         }
 
         bool operator==(const permuter& x) const {
-            return x_ == x.x_;
+            return x_.load(std::memory_order_acquire) == x.x_.load(std::memory_order_acquire);
         }
         bool operator!=(const permuter& x) const {
             return !(*this == x);
         }
 
         int operator&(uint64_t mask) {
-            return x_ & mask;
+            return x_.load(std::memory_order_acquire) & mask;
         }
 
         void operator>>=(uint64_t mask) {
-            x_ = (x_ >> mask);
+            x_.store( (x_.load(std::memory_order_acquire) >> mask), std::memory_order_release);
         }
 
         static inline int size(uint64_t p) {
@@ -323,7 +327,7 @@ class permuter {
         }
 
     private:
-        uint64_t x_;
+        std::atomic<uint64_t> x_;
 };
 
 class leafnode {

--- a/P-Masstree/masstree.h
+++ b/P-Masstree/masstree.h
@@ -62,7 +62,7 @@ typedef struct key_indexed_position {
 
 class masstree {
     private:
-        void *root_;
+        std::atomic<void *> root_;
 
         MASS::Epoche epoche{256};
     public:
@@ -75,9 +75,9 @@ class masstree {
 
         MASS::ThreadInfo getThreadInfo();
 
-        void *root() {return root_;}
+        void *root() {return root_.load(std::memory_order_acquire);}
 
-        void **root_dp() {return &root_;}
+        std::atomic<void *>*root_dp() {return &root_;}
 
         void setNewRoot(void *new_root);
 
@@ -430,7 +430,7 @@ class leafnode {
 
         leafvalue *smallest_leaf(size_t key_len, uint64_t value);
 
-        leafnode *search_for_leftsibling(void **root, uint64_t key, uint32_t level, leafnode *right);
+        leafnode *search_for_leftsibling(std::atomic<void *>*root, uint64_t key, uint32_t level, leafnode *right);
 };
 
 }


### PR DESCRIPTION
We have been working on a bug-finding tool to identify a new class of bugs in persistent memory programs, which we call persistency races. 
Our observation is that many PM programmers incorrectly assume that stores to persistent memory are atomic, i.e., that if the program crashes those stores will either be made persistent or they will not. Our observation is that the compiler may implement a non-atomic store using multiple store instructions (which is called store tearing) due to optimizations [1]. Consequently, a poorly timed crash event in the middle of such writes can cause a non-atomic store to be made partially persistent.  As a result,  a load in the post-crash execution can potentially read a mixture of values from different stores. We refer to this new class of persistency bugs as persistency races due to their relation to data races since the crash event effectively races with the stores and thus causes compiler optimizations to introduce bugs.
These stores can be an index of an array or a pointer to an object in the memory and similar to other persistency bugs, reading invalid values in post-crash can cause the program to crash. 
The fix is to replace racing non-atomic stores with atomic ones.  On x86 this typically incurs no overhead because release stores are implemented with normal move instructions.  But it suffices to ensure that compiler optimizations will not cause store tearing.  While a specific compiler may not perform these optimizations, the fact that it can means that compiler upgrades, architectural changes, or even unrelated changes to the code can cause optimizations to generate problematic assembly.
This pull request contain a bug fix for 2 variables, compactCount and count, in P-ART benchmark and 3 variables, root_, next, and x_, in P-Masstree benchmark. This bug fix prevents compilers from optimizing these variables causing persistency races in the program. The bug fix makes these variables and all the corresponding accesses to them atomic.