### PR TITLE
Fix bug of memcmp of string keys whose length mod 8 < 4

### DIFF
--- a/P-Masstree/masstree.h
+++ b/P-Masstree/masstree.h
@@ -112,6 +112,15 @@ class permuter {
         permuter(uint64_t x) : x_(x) {
         }
 
+        permuter(const permuter &rhs) {
+            x_.store(rhs.x_.load(std::memory_order_acquire), std::memory_order_release);
+        }
+
+        permuter &operator=(const permuter &rhs) {
+            x_.store(rhs.x_.load(std::memory_order_acquire), std::memory_order_release);
+            return *this;
+        }
+
         /** @brief Return an empty permuter with size 0.
 
           Elements will be allocated in order 0, 1, ..., @a width - 1. */


### PR DESCRIPTION
The original way for P-Masstree to identify whether two strings are equal is using `memcmp` to compare only **length-of-string** bytes. However, if these strings are all of the length of 9 bytes, for `bswap` performed, the last byte of them are actually at the **MSB of** the second `uint64_t`. Therefore, we should compare fully on all these `uint64_t`s, not just length-of-string bytes.

 Code which can cause error can be like this:
```c++
#include <iostream>
#include "masstree.h"
using namespace std;

int main() {
    masstree::masstree *tree = new masstree::masstree();
    auto info = tree->getThreadInfo();
    char *s1 = "123456789";
    tree->put(s1, 123, info);
    char *s2 = "123456780";
    tree->put(s2, 456, info);
    printf("%ld\n", (int64_t)tree->get(s1, info));
    printf("%ld\n", (int64_t)tree->get(s2, info));
}
```

Expected output:
```
123
456
```

Actual output:
```
456
456
```